### PR TITLE
chore: upgrade terraform to 1.12.0 and bump version

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Run Super-Linter
         uses: github/super-linter@main
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:3.21.3 AS build
-LABEL version="0.3.4"
+LABEL version="0.3.5"
 LABEL release="pipetools"
 LABEL maintainer="marcinbojko"
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 COPY entrypoint.sh /entrypoint.sh
 # additions
-COPY --from=hashicorp/terraform:1.11.4 /bin/terraform /bin/terraform
+COPY --from=hashicorp/terraform:1.12.0 /bin/terraform /bin/terraform
 COPY --from=anchore/syft:v1.23.1 /syft /bin/syft
 COPY --from=hadolint/hadolint:v2.12.0 /bin/hadolint /bin/hadolint
 COPY --from=ghcr.io/terraform-linters/tflint:v0.52.0 /usr/local/bin/tflint /bin/tflint


### PR DESCRIPTION
Updates terraform from version 1.11.4 to 1.12.0
Increases image version from 0.3.4 to 0.3.5

Maintains other dependencies at their current versions:
- syft v1.23.1
- hadolint v2.12.0
- tflint v0.52.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Docker image to use Terraform version 1.12.0.
  - Incremented version label to 0.3.5.
  - Enhanced CI workflow to fetch full Git history for improved linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->